### PR TITLE
fix: centralize axios instance and improve error handling

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,6 +1,3 @@
-import axios from "axios"
-import { BASE_URL } from "@/constants/config"
-import { ApiError } from "./errors/ApiError"
 import { api } from "@/lib/axios"
 
 export type User = {
@@ -25,7 +22,7 @@ export interface AuthResponse {
 export class AuthAPI{
 
     static async signup({name, lastName, email, password}: {name: string, lastName: string, email: string, password: string}): Promise<AuthResponse> {
-        const response = await api.post(`${BASE_URL}/auth/signup`, {
+        const response = await api.post(`/auth/signup`, {
             name, 
             lastName,
             email,
@@ -36,27 +33,23 @@ export class AuthAPI{
     }
 
     static async login({email, password}: {email:string, password: string}): Promise<AuthResponse> {
-        try {
-            const response = await api.post(`/auth/login`, {
-                email,
-                password
-            }, {
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json'
-                }
-            })            
+        const response = await api.post(`/auth/login`, {
+            email,
+            password
+        }, {
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            }
+        })            
 
-            return response.data
-        } catch (error: any) {            
-            throw new ApiError(error.response.data.message, error.response.status)
-        }
+        return response.data
 
     }
 
     static async validateToken(token: string): Promise<boolean> {
         try {
-            const res = await api.get(`${BASE_URL}/auth/validate`, {
+            const res = await api.get(`/auth/validate`, {
                 headers: {
                     Authorization: `Bearer ${token}`
                 }

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,6 +1,7 @@
 import axios from "axios"
 import { BASE_URL } from "@/constants/config"
 import { ApiError } from "./errors/ApiError"
+import { api } from "@/lib/axios"
 
 export type User = {
     id: string
@@ -24,29 +25,19 @@ export interface AuthResponse {
 export class AuthAPI{
 
     static async signup({name, lastName, email, password}: {name: string, lastName: string, email: string, password: string}): Promise<AuthResponse> {
-        try {            
-            const response = await axios.post(`${BASE_URL}/auth/signup`, {
-                name, 
-                lastName,
-                email,
-                password
-            },
-            {
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json'
-                }
-            })
+        const response = await api.post(`${BASE_URL}/auth/signup`, {
+            name, 
+            lastName,
+            email,
+            password
+        })
 
-            return response.data
-        } catch (error: any) {
-            throw new ApiError(error.response.data.message, error.response.status)
-        }
+        return response.data
     }
 
     static async login({email, password}: {email:string, password: string}): Promise<AuthResponse> {
         try {
-            const response = await axios.post(`${BASE_URL}/auth/login`, {
+            const response = await api.post(`/auth/login`, {
                 email,
                 password
             }, {
@@ -65,7 +56,7 @@ export class AuthAPI{
 
     static async validateToken(token: string): Promise<boolean> {
         try {
-            const res = await axios.get(`${BASE_URL}/auth/validate`, {
+            const res = await api.get(`${BASE_URL}/auth/validate`, {
                 headers: {
                     Authorization: `Bearer ${token}`
                 }

--- a/api/errors/ApiError.ts
+++ b/api/errors/ApiError.ts
@@ -1,7 +1,7 @@
-export class ApiError extends Error{
+export class ApiError<T = any> extends Error{
     status: number
-    data: any | undefined
-    constructor (message: string, status: number, data?: any){
+    data?: T
+    constructor (message: string, status: number, data?: T){
         super(message)
         this.status = status
         this.data = data

--- a/api/ingredients.ts
+++ b/api/ingredients.ts
@@ -1,22 +1,21 @@
-import { BASE_URL } from "@/constants/config";
+import { api } from "@/lib/axios";
 import { Ingredient } from "@/types/ingredients";
-import axios from "axios";
 
 export class IngredientsAPI {
     static async getIngredients() {
-        const {data} = await axios.get(`${BASE_URL}/ingredient`)
-        
-        return data
+        const response = await api.get<Ingredient[]>('/ingredient')        
+
+        return response.data
     }
 
     static async getIngredient({id}: {id: string}){
-        const {data} = await axios.get(`${BASE_URL}/ingredient/${id}`)
+        const {data} = await api.get(`/ingredient/${id}`)
         
         return data
     }
 
     static async createIngredient(ingredient: Ingredient){
-        const {data} = await axios.post(`${BASE_URL}/ingredient`, {
+        const {data} = await api.post(`/ingredient`, {
             data: ingredient
         })
 
@@ -24,7 +23,7 @@ export class IngredientsAPI {
     }
 
     static async updateIngredient(ingredient: Ingredient){
-        const {data} = await axios.put(`${BASE_URL}/ingredient/${ingredient.id}`, {
+        const {data} = await api.put(`/ingredient/${ingredient.id}`, {
             data: ingredient
         })
         

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,6 +1,6 @@
 import { ThemedText } from "@/components/text/ThemedText"
 import { ThemedView } from "@/components/view/ThemedView"
-import { useApiError } from "@/hooks/useApiError"
+import { ErrorScope, useApiError } from "@/hooks/useApiError"
 import { useSession } from "@/hooks/useAuth"
 import { useTheme } from "@/hooks/useTheme"
 import { Stack, Link } from "expo-router"
@@ -21,9 +21,8 @@ export default function LoginScreen(){
         try {
             await signIn({email, password})
         } catch (error: any) {
-            const message = handleError(error, "Error al iniciar sesión", "auth")         
+            const message = handleError(error, "Error al iniciar sesión", ErrorScope.AUTH)         
             setError(message)
-            throw new Error('Error al iniciar sesión. ' + error.message)
         }
     }
     return(

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,5 +1,6 @@
 import { ThemedText } from "@/components/text/ThemedText"
 import { ThemedView } from "@/components/view/ThemedView"
+import { AUTH_ERRORS } from "@/constants/auth.constants"
 import { ErrorScope, useApiError } from "@/hooks/useApiError"
 import { useSession } from "@/hooks/useAuth"
 import { useTheme } from "@/hooks/useTheme"
@@ -21,7 +22,7 @@ export default function LoginScreen(){
         try {
             await signIn({email, password})
         } catch (error: any) {
-            const message = handleError(error, "Error al iniciar sesión", ErrorScope.AUTH)         
+            const message = handleError(error, AUTH_ERRORS.LOGIN_ERROR, ErrorScope.AUTH)         
             setError(message)
         }
     }

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,7 +1,7 @@
 import { ThemedText } from "@/components/text/ThemedText"
 import { ThemedView } from "@/components/view/ThemedView"
 import { AUTH_ERRORS } from "@/constants/auth.constants"
-import { useApiError } from "@/hooks/useApiError"
+import { ErrorScope, useApiError } from "@/hooks/useApiError"
 import { useSession } from "@/hooks/useAuth"
 import { useTheme } from "@/hooks/useTheme"
 import { Stack, Link } from "expo-router"
@@ -23,7 +23,7 @@ export default function RegisterScreen(){
         try {
            await signUp({name, lastName, email, password});
         } catch (error: any) {
-            const message = handleError(error, AUTH_ERRORS.SIGNUP_ERROR, "auth")
+            const message = handleError(error, AUTH_ERRORS.SIGNUP_ERROR, ErrorScope.AUTH)
             setErrorMessage(message)
         } 
     }

--- a/app/(tabs)/inventary.tsx
+++ b/app/(tabs)/inventary.tsx
@@ -9,13 +9,13 @@ import { useEffect, useState } from "react";
 export default function InventaryScreen(){
     const [ingredients, setIngredients] = useState<Ingredient[]>([])    
 
-    useEffect(() => {        
-        const fetchIngredients = async () => {
-            const response = await IngredientsAPI.getIngredients()
-            
-            setIngredients(response.data)
+    useEffect(() => {                
+        const fetchIngredients = async () => {            
+            const ingredients = await IngredientsAPI.getIngredients()
+
+            setIngredients(ingredients)
         }
-    
+        
         fetchIngredients()
     }, []);    
     

--- a/hooks/useApiError.ts
+++ b/hooks/useApiError.ts
@@ -1,8 +1,14 @@
 import { ApiError } from "@/api/errors/ApiError";
 import { errorHandlers } from "@/api/errors/errorMessages"
 
+export enum ErrorScope{
+   AUTH = 'auth',
+   USER = 'user',
+   INGREDIENTS =  'ingredients'
+}
+
 export function useApiError(){
-    const handleError = (error: unknown, fallbackMessage: string = 'Ocurrió un error inesperado.', scope: string = ""): string => {
+    const handleError = (error: unknown, fallbackMessage: string = 'Ocurrió un error inesperado.', scope: ErrorScope): string => {
         if(error instanceof ApiError && scope in errorHandlers){ 
             return errorHandlers[scope](error) || fallbackMessage
         }

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,0 +1,33 @@
+import { ApiError } from "@/api/errors/ApiError";
+import { BASE_URL } from "@/constants/config";
+import axios from "axios";
+import { getItemAsync } from "expo-secure-store";
+
+export const api = axios.create({
+    baseURL: BASE_URL,
+    headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+    },
+})
+
+api.interceptors.request.use(async (config) => {
+    const token = await getItemAsync("session")
+
+    if(token){
+        config.headers.Authorization = `Bearer ${token}`
+    }
+
+    return config
+})
+
+api.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        const status = error.response?.status || 500
+        const message = error.response?.data?.message || "Internal Server Error"
+        const data = error.response?.data || null
+
+        return Promise.reject(new ApiError(message, status, data))
+    }
+)


### PR DESCRIPTION
- Created reusable Axios instance with interceptors
- Removed redundant try-catch blocks and headers
- Simplified API calls and removed BASE_URL constant
- Added generics and ErrorScope enum to ApiError
- Improved TS types and code consistency across endpoints